### PR TITLE
Design fix of forward screen

### DIFF
--- a/templates/forward.php
+++ b/templates/forward.php
@@ -4,7 +4,7 @@
 	style('core', 'guest');
 	?>
 
-	<div class="update bbb">
+	<div class="update bbb guest-box">
 		<h2><?php p($_['room']) ?></h2>
 		<p><?php p($l->t('You will be forwarded to the room in the next few seconds.')); ?><br />
 			<br />


### PR DESCRIPTION
Signed-off-by: Jérôme Herbinet <33763786+Jerome-Herbinet@users.noreply.github.com>

Often, part of the text is difficult to read, depending on the background color and the user theme (light or dark). This block (appearing thanks to an existing CSS class taken from nextcloud-vue) seems to solve the problem. 

**A test from you and any other reviewer is welcome before merging. See if it's OK in light and dark themes.**

## Before
![Capture d’écran du 2023-10-26 15-12-10](https://github.com/sualko/cloud_bbb/assets/33763786/12219b90-27e7-4f29-bac1-488e1b4d02f9)

## After
![Capture d’écran du 2023-10-26 15-12-16](https://github.com/sualko/cloud_bbb/assets/33763786/3d9ce1fa-5db3-49c1-940f-7a192c38d370)
