### PR TITLE
Make compatible for Nextcloud 28

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -43,7 +43,7 @@ Developer wanted! If you have time it would be awesome if you could help to enha
         <lib>curl</lib>
         <lib>mbstring</lib>
         <lib>SimpleXML</lib>
-        <nextcloud min-version="25" max-version="27"/>
+        <nextcloud min-version="25" max-version="28"/>
     </dependencies>
     <commands>
         <command>OCA\BigBlueButton\Command\ClearAvatarCache</command>


### PR DESCRIPTION
Hi @sualko :wave: 

I functionally tested the app for Nextcloud 28 and it works !

Notice : I could not install dependencies and build the project. So, I tested it by installing the latest version with this artifact : https://github.com/littleredbutton/cloud_bbb/releases/tag/v2.5.0 .