### PR TITLE
feat: add option to not use avatars in BBB rooms

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Key                               | Description
 `app.shortener`                   | Value of your shortener service. Should start with `https://` and contain `{token}`.
 `avatar.path`                     | Absolute path to an optional avatar cache directory.
 `avatar.url`                      | URL which serves `avatar.path` to be used as avatar cache.
+`avatar.enabled`                  | Set to `false` if you want to disable the use of Nextcloud avatars in BBB rooms.
 
 ### Avatar cache (v2.2+)
 The generation of avatars puts a high load on your Nextcloud instance, since the
@@ -113,8 +114,8 @@ For additional security, we recommend to disable directory listing, symlinks and
 any language interpreter such as php for the cache directory.
 
 Cached avatars are usually deleted as soon as the meeting ends. In cases the BBB
-server shuts down unexpected, we provide the `bbb:clear-avatar-cache` occ
-command (example use: `./occ bbb:clear-avatar-cache`).
+server shuts down unexpected or you set `avatar.enabled` to `false` (via gui or manually) while a meeting was running, 
+we provide the `bbb:clear-avatar-cache` occ command (example use: `./occ bbb:clear-avatar-cache`).
 
 
 ## :bowtie: User guide

--- a/lib/BigBlueButton/API.php
+++ b/lib/BigBlueButton/API.php
@@ -130,10 +130,12 @@ class API {
 		}
 
 		if ($uid) {
-			$avatarUrl = $this->avatarRepository->getAvatarUrl($room, $uid);
-
 			$joinMeetingParams->setUserID($uid);
-			$joinMeetingParams->setAvatarURL($avatarUrl);
+
+			if ($this->config->getAppValue('bbb', 'avatar.enabled', 'true') === 'true') {
+				$avatarUrl = $this->avatarRepository->getAvatarUrl($room, $uid);
+				$joinMeetingParams->setAvatarURL($avatarUrl);
+			}
 		}
 
 		return $this->getServer()->getJoinMeetingURL($joinMeetingParams);

--- a/lib/Controller/HookController.php
+++ b/lib/Controller/HookController.php
@@ -7,6 +7,7 @@ use OCA\BigBlueButton\Db\Room;
 use OCA\BigBlueButton\Event\MeetingEndedEvent;
 use OCA\BigBlueButton\Event\RecordingReadyEvent;
 use OCA\BigBlueButton\Service\RoomService;
+use OCP\IConfig;
 use OCP\AppFramework\Controller;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IRequest;
@@ -27,18 +28,23 @@ class HookController extends Controller {
 	/** @var IEventDispatcher */
 	private $eventDispatcher;
 
+	/** @var IConfig */
+	private $config;
+
 	public function __construct(
 		string $appName,
 		IRequest $request,
 		RoomService $service,
 		AvatarRepository $avatarRepository,
-		IEventDispatcher $eventDispatcher
+		IEventDispatcher $eventDispatcher,
+		IConfig $config
 	) {
 		parent::__construct($appName, $request);
 
 		$this->service = $service;
 		$this->avatarRepository = $avatarRepository;
 		$this->eventDispatcher = $eventDispatcher;
+		$this->config = $config;
 	}
 
 	public function setToken(string $token): void {
@@ -65,7 +71,9 @@ class HookController extends Controller {
 
 		$this->service->updateRunning($room->getId(), false);
 
-		$this->avatarRepository->clearRoom($room->uid);
+		if ($this->config->getAppValue('bbb', 'avatar.enabled', 'true') === 'true') {
+			$this->avatarRepository->clearRoom($room->uid);
+		}		
 
 		$this->eventDispatcher->dispatch(MeetingEndedEvent::class, new MeetingEndedEvent($room, $recordingmarks));
 	}

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -30,6 +30,7 @@ class Admin implements ISettings {
 			'join.theme' => $this->config->getAppValue('bbb', 'join.theme') === 'true' ? 'checked' : '',
 			'app.shortener' => $this->config->getAppValue('bbb', 'app.shortener'),
 			'join.mediaCheck' => $this->config->getAppValue('bbb', 'join.mediaCheck', 'true') === 'true' ? 'checked' : '',
+			'avatar.enabled' => $this->config->getAppValue('bbb', 'avatar.enabled', 'true') === 'true' ? 'checked' : '',
 		];
 
 		return new TemplateResponse('bbb', 'admin', $parameters);

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -29,6 +29,11 @@ script('bbb', 'restrictions');
             <label for="bbb-join-theme"><?php p($l->t('Use Nextcloud theme in BigBlueButton.')); ?></label>
         </p>
 
+        <p>
+            <input type="checkbox" name="avatar.enabled" id="bbb-avatar-enabled" class="checkbox bbb-setting" value="1" <?php p($_['avatar.enabled']); ?> />
+            <label for="bbb-avatar-enabled"><?php p($l->t('Use Nextcloud avatars in BBB rooms.')); ?></label>
+        </p>
+
         <h3><?php p($l->t('Default Room Settings')); ?></h3>
         <p><?php p($l->t('Below you can change some default values, which are used to create a new room.')); ?></p>
 


### PR DESCRIPTION
This commit adds an admin option to globally disable the use of Nextcloud avatars in BBB rooms.

If an avatar-cache is configured and a meeting is running while changing this setting, the avatars of these meetings will not be cleared. In that case the command-line argument (see README) needs to be used.

Fixes issue #268 