### PR TITLE
fix: add new hide_presentation_on_join flag

### DIFF
--- a/lib/BigBlueButton/API.php
+++ b/lib/BigBlueButton/API.php
@@ -117,7 +117,8 @@ class API {
 		$joinMeetingParams->addUserData('bbb_skip_video_preview_on_first_join', !$room->getMediaCheck()); // 2.3
 
 		if ($room->getCleanLayout()) {
-			$joinMeetingParams->addUserData('bbb_auto_swap_layout', true);
+			$joinMeetingParams->addUserData('bbb_auto_swap_layout', true); // 2.5 and below // ToDo: remove in the future
+			$joinMeetingParams->addUserData('bbb_hide_presentation_on_join', true); // 2.6 and up
 			$joinMeetingParams->addUserData('bbb_show_participants_on_login', false);
 			$joinMeetingParams->addUserData('bbb_show_public_chat_on_login', false);
 		}


### PR DESCRIPTION
As of BBB 2.6 the userdata flag for hiding the presentation has changed. This commit adds the new `bbb_hide_presentation_on_join` flag when a clean layout is selected.

In order to keep backwards compatability for BBB 2.5 and lower we can send both flags and remove the deprecated one later on.

Fixes issue #243 