### PR TITLE
Fix avatar size in sharing modal

### DIFF
--- a/ts/Manager/ShareWith.scss
+++ b/ts/Manager/ShareWith.scss
@@ -20,6 +20,10 @@
       width: 32px;
       overflow: hidden;
 
+      > img {
+        max-width: 100%;
+      }
+
       .icon-group-white,
       .icon-circle-white {
         display: block;


### PR DESCRIPTION
**I need reviewer(s) to test it in their test environment before merging, in order to verify if :**
- it really fixes the problem
- it doesn't create side effect with avatars in the rooms' list (avatars from shares' senders)

## Before 
![2024-09-09_10-59_1](https://github.com/user-attachments/assets/02c4f107-bf40-4a8d-a3e4-7d87371f754d)

## After 
![2024-09-09_10-59](https://github.com/user-attachments/assets/918e9f83-dae8-41ed-982b-0bf6890154ca)

