### PR TITLE
fix: style lint warnings and typescript compiler need upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
 		"stylelint-config-recommended-scss": "^5.0.2",
 		"stylelint-scss": "^4.2.0",
 		"ts-loader": "^9.2.8",
-		"typescript": "^4.0.2",
+		"typescript": "^4.9.3",
 		"url-loader": "^4.0.0",
 		"webpack": "^5.70.0",
 		"webpack-cli": "^4.9.2",

--- a/ts/Manager/App.scss
+++ b/ts/Manager/App.scss
@@ -37,6 +37,36 @@
   opacity: 0.6;
 }
 
+.bbb-qrcode-container {
+  display: block;
+  height: 34px;
+  width: 34px;
+  margin: 3px;
+  position: relative;
+  cursor: zoom-in;
+
+  canvas {
+    max-width: 100%;
+    max-height: 100%;
+    position: absolute;
+    top: 0;
+    right: 0;
+  }
+
+  input[type="checkbox"] {
+    display: none;
+
+    &:checked + canvas {
+      max-width: none;
+      max-height: none;
+      box-shadow: 0 0 10px;
+      box-shadow: 0 0 5px var(--color-box-shadow);
+      cursor: zoom-out;
+      border: 5px solid #fff;
+    }
+  }
+}
+
 #bbb-root, #bbb-app {
   width: 100%;
   background-color: var(--color-main-background);
@@ -93,10 +123,6 @@ pre {
   form {
     margin-bottom: 2em;
   }
-}
-
-#bbb-react-root table tbody tr td {
-  border-bottom: 1px solid var(--color-border-dark);
 }
 
 #bbb-react-root,
@@ -194,6 +220,7 @@ pre {
     padding: 0 6px;
     position: relative;
     display: table-cell;
+    border-bottom: 1px solid var(--color-border-dark);
 
     & > form {
       margin: -10px;
@@ -298,39 +325,9 @@ pre {
 }
 
 .bbb-simple-menu {
-	min-width: auto;
+  min-width: auto;
 }
 
 .bbb-input-container {
   display: flex;
-}
-
-.bbb-qrcode-container {
-  display: block;
-  height: 34px;
-  width: 34px;
-  margin: 3px;
-  position: relative;
-  cursor: zoom-in;
-
-  canvas {
-    max-width: 100%;
-    max-height: 100%;
-    position: absolute;
-    top: 0;
-    right: 0;
-  }
-
-  input[type="checkbox"] {
-    display: none;
-
-    &:checked + canvas {
-      max-width: none;
-      max-height: none;
-      box-shadow: 0 0 10px;
-      box-shadow: 0 0 5px var(--color-box-shadow);
-      cursor: zoom-out;
-      border: 5px solid #fff;
-    }
-  }
 }


### PR DESCRIPTION
- Typescript need to be upgraded for NC30 support

- Many SCSS warnings are blocking the build and the commit action