### PR TITLE
fix: update php versions for tests in github actions

### DIFF
--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -15,13 +15,25 @@ jobs:
         nextcloud-versions: ['stable25', 'stable26', 'stable27', 'stable28','stable29', 'stable30']
         exclude:
           - php-versions: '7.4'
-            nextcloud-versions: ['stable26', 'stable27', 'stable28', 'stable29', 'stable30']
+            nextcloud-versions: 'stable26'
+          - php-versions: '7.4'
+            nextcloud-versions: 'stable27'
+          - php-versions: '7.4'
+            nextcloud-versions: 'stable28'
+          - php-versions: '7.4'
+            nextcloud-versions: 'stable29'
+          - php-versions: '7.4'
+            nextcloud-versions: 'stable30'
           - php-versions: '8.0'
             nextcloud-versions: 'stable30'
           - php-versions: '8.2'
             nextcloud-versions: 'stable25'
           - php-versions: '8.3'
-            nextcloud-versions: ['stable25', 'stable26', 'stable27']
+            nextcloud-versions: 'stable25'
+          - php-versions: '8.3'
+            nextcloud-versions: 'stable26'
+          - php-versions: '8.3'
+            nextcloud-versions: 'stable27'
     name: php${{ matrix.php-versions }} on ${{ matrix.nextcloud-versions }} unit tests
     env:
       CI: true

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
-        nextcloud-versions: ['stable25', 'stable26', 'stable27', 'stable28','stable29', 'stable30']
+        nextcloud-versions: ['stable25', 'stable26', 'stable27', 'stable28']
         exclude:
           - php-versions: '7.4'
             nextcloud-versions: 'stable26'
@@ -20,12 +20,6 @@ jobs:
             nextcloud-versions: 'stable27'
           - php-versions: '7.4'
             nextcloud-versions: 'stable28'
-          - php-versions: '7.4'
-            nextcloud-versions: 'stable29'
-          - php-versions: '7.4'
-            nextcloud-versions: 'stable30'
-          - php-versions: '8.0'
-            nextcloud-versions: 'stable30'
           - php-versions: '8.2'
             nextcloud-versions: 'stable25'
           - php-versions: '8.3'

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -11,13 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.4', '8']
-        nextcloud-versions: ['stable25', 'stable26', 'stable27']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        nextcloud-versions: ['stable25', 'stable26', 'stable27', 'stable28','stable29', 'stable30']
         exclude:
           - php-versions: '7.4'
-            nextcloud-versions: 'stable26'
-          - php-versions: '7.4'
-            nextcloud-versions: 'stable27'
+            nextcloud-versions: ['stable26', 'stable27', 'stable28', 'stable29', 'stable30']
+          - php-versions: '8.0'
+            nextcloud-versions: 'stable30'
+          - php-versions: '8.2'
+            nextcloud-versions: 'stable25'
+          - php-versions: '8.3'
+            nextcloud-versions: ['stable25', 'stable26', 'stable27']
     name: php${{ matrix.php-versions }} on ${{ matrix.nextcloud-versions }} unit tests
     env:
       CI: true


### PR DESCRIPTION
From 25 to 30, with php 7.4 to 8.3