### PR TITLE
fix: throw UnknownActivityException in activity provider

### DIFF
--- a/lib/Activity/Provider.php
+++ b/lib/Activity/Provider.php
@@ -4,6 +4,7 @@ namespace OCA\BigBlueButton\Activity;
 
 use OCA\BigBlueButton\AppInfo\Application;
 use OCA\BigBlueButton\Db\RoomShare;
+use OCP\Activity\Exceptions\UnknownActivityException;
 use OCP\Activity\IEvent;
 use OCP\Activity\IManager;
 use OCP\Activity\IProvider;
@@ -70,7 +71,7 @@ class Provider implements IProvider {
 
 	public function parse($language, IEvent $event, ?IEvent $previousEvent = null) {
 		if ($event->getApp() !== Application::ID) {
-			throw new \InvalidArgumentException();
+			throw new UnknownActivityException();
 		}
 
 		$this->l = $this->languageFactory->get(Application::ID, $language);


### PR DESCRIPTION
### Summary

On Nextcloud 30+ the activity framework logs a deprecation warning every time a notification/activity fetch touches a BBB event:

```
OCA\BigBlueButton\Activity\Provider::parse() threw \InvalidArgumentException which is deprecated.
Throw \OCP\Activity\Exceptions\UnknownActivityException when the event is not known to your provider
and otherwise handle all \InvalidArgumentException yourself.
```

On a busy instance this shows up in the log for practically every user with BBB activities, drowning out real problems.

This PR switches the "not my app" guard in `Provider::parse()` to the dedicated `UnknownActivityException`, as requested by the deprecation message.

### Compatibility

`OCP\Activity\Exceptions\UnknownActivityException` exists since Nextcloud 30 (`@since 30.0.0`), well below the app's current `min-version="33"` — no conditional handling needed.

### Test

Running with this change on Nextcloud 34.0.3: activities render as before and the deprecation warning is gone from the log.
